### PR TITLE
Add basic charts and graphs for data visualization

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -10,7 +10,8 @@ from sentiment_analysis import analyze_sentiment, generate_sentiment_trends
 from data_visualization import (
     create_wordcloud,
     create_sentiment_distribution,
-    create_engagement_visualization
+    create_engagement_visualization,
+    create_basic_charts
 )
 from utils import extract_video_id, setup_logging
 
@@ -116,6 +117,22 @@ def engagement_route():
         return send_file(filename)
     except Exception as e:
         logger.error(f"Error generating engagement visualization: {e}")
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/visualizations/<video_id>/<chart_type>')
+def visualizations_route(video_id, chart_type):
+    try:
+        video_id = extract_video_id(video_id)
+        comments = get_video_comments(youtube, video_id)
+        output_dir = 'visualizations'
+        charts = create_basic_charts(comments, output_dir)
+        chart_file = charts.get(chart_type)
+        if chart_file:
+            return send_file(chart_file)
+        else:
+            return jsonify({'error': 'Invalid chart type'}), 400
+    except Exception as e:
+        logger.error(f"Error generating visualization: {e}")
         return jsonify({'error': str(e)}), 500
 
 if __name__ == '__main__':

--- a/data_visualization.py
+++ b/data_visualization.py
@@ -367,3 +367,37 @@ class RealtimeVisualizer:
             "topic_distribution": create_topic_distribution(data),
             "engagement_metrics": create_engagement_metrics(data),
         }
+
+
+def create_basic_charts(data, output_dir):
+    """Generate basic charts and graphs using matplotlib and plotly."""
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    # Line Chart
+    plt.figure(figsize=(10, 6))
+    plt.plot(data["date"], data["sentiment"], marker="o")
+    plt.title("Sentiment Analysis")
+    plt.xlabel("Date")
+    plt.ylabel("Sentiment Score")
+    plt.grid(True)
+    line_chart_path = os.path.join(output_dir, "line_chart.html")
+    plt.savefig(line_chart_path)
+    plt.close()
+
+    # Bar Chart
+    fig = px.bar(data, x="date", y="sentiment", title="Sentiment Bar Chart")
+    bar_chart_path = os.path.join(output_dir, "bar_chart.html")
+    fig.write_html(bar_chart_path)
+
+    # Pie Chart
+    sentiment_counts = data["sentiment"].value_counts()
+    fig = px.pie(sentiment_counts, values=sentiment_counts.values, names=sentiment_counts.index, title="Sentiment Pie Chart")
+    pie_chart_path = os.path.join(output_dir, "pie_chart.html")
+    fig.write_html(pie_chart_path)
+
+    return {
+        "line_chart": line_chart_path,
+        "bar_chart": bar_chart_path,
+        "pie_chart": pie_chart_path
+    }

--- a/frontend/src/webui/components/visualization/SentimentChart.tsx
+++ b/frontend/src/webui/components/visualization/SentimentChart.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from "react"
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts"
+import { LineChart, Line, BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts"
+import Plot from 'react-plotly.js';
 
 interface SentimentData {
 	timestamp: number
@@ -10,9 +11,12 @@ interface SentimentData {
 interface Props {
 	data: SentimentData[]
 	loading?: boolean
+	chartType: "line" | "bar" | "pie"
 }
 
-export const SentimentChart: React.FC<Props> = ({ data, loading }) => {
+const COLORS = ["#8884d8", "#82ca9d", "#ffc658"]
+
+export const SentimentChart: React.FC<Props> = ({ data, loading, chartType }) => {
 	const chartRef = useRef(null)
 
 	useEffect(() => {
@@ -25,22 +29,59 @@ export const SentimentChart: React.FC<Props> = ({ data, loading }) => {
 		return <VSCodeProgressRing />
 	}
 
+	const renderChart = () => {
+		switch (chartType) {
+			case "bar":
+				return (
+					<Plot
+						data={[
+							{
+								x: data.map(d => new Date(d.timestamp).toLocaleDateString()),
+								y: data.map(d => d.sentiment),
+								type: 'bar',
+								marker: { color: '#8884d8' },
+							},
+						]}
+						layout={{ title: 'Sentiment Bar Chart' }}
+					/>
+				)
+			case "pie":
+				return (
+					<Plot
+						data={[
+							{
+								values: data.map(d => d.sentiment),
+								labels: data.map(d => new Date(d.timestamp).toLocaleDateString()),
+								type: 'pie',
+								marker: { colors: COLORS },
+							},
+						]}
+						layout={{ title: 'Sentiment Pie Chart' }}
+					/>
+				)
+			case "line":
+			default:
+				return (
+					<Plot
+						data={[
+							{
+								x: data.map(d => new Date(d.timestamp).toLocaleDateString()),
+								y: data.map(d => d.sentiment),
+								type: 'scatter',
+								mode: 'lines+markers',
+								marker: { color: '#8884d8' },
+							},
+						]}
+						layout={{ title: 'Sentiment Line Chart' }}
+					/>
+				)
+		}
+	}
+
 	return (
 		<div className="chart-container">
 			<ResponsiveContainer width="100%" height={300}>
-				<LineChart ref={chartRef} data={data}>
-					<CartesianGrid strokeDasharray="3 3" />
-					<XAxis
-						dataKey="timestamp"
-						tickFormatter={(timestamp) => new Date(timestamp).toLocaleDateString()}
-					/>
-					<YAxis domain={[-1, 1]} />
-					<Tooltip
-						labelFormatter={(timestamp) => new Date(timestamp).toLocaleString()}
-						formatter={(value) => [Number(value).toFixed(2), "Sentiment"]}
-					/>
-					<Line type="monotone" dataKey="sentiment" stroke="#8884d8" strokeWidth={2} dot={false} />
-				</LineChart>
+				{renderChart()}
 			</ResponsiveContainer>
 		</div>
 	)

--- a/frontend/src/youtube_app/CommentsDisplay.js
+++ b/frontend/src/youtube_app/CommentsDisplay.js
@@ -1,9 +1,65 @@
 import React from 'react';
+import { LineChart, Line, BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import Plot from 'react-plotly.js';
 
-function CommentsDisplay({ comments }) {
+function CommentsDisplay({ comments, chartType }) {
   if (!comments || comments.length === 0) {
     return <div>No comments to display.</div>;
   }
+
+  const renderChart = () => {
+    switch (chartType) {
+      case "bar":
+        return (
+          <Plot
+            data={[
+              {
+                x: comments.map((comment, index) => `Comment ${index + 1}`),
+                y: comments.map(comment => comment.sentiment.compound),
+                type: 'bar',
+                marker: { color: '#8884d8' },
+              },
+            ]}
+            layout={{ title: 'Sentiment Bar Chart' }}
+          />
+        );
+      case "pie":
+        const sentimentCounts = comments.reduce((acc, comment) => {
+          const sentiment = comment.sentiment.compound >= 0.05 ? 'Positive' : comment.sentiment.compound <= -0.05 ? 'Negative' : 'Neutral';
+          acc[sentiment] = (acc[sentiment] || 0) + 1;
+          return acc;
+        }, {});
+        return (
+          <Plot
+            data={[
+              {
+                values: Object.values(sentimentCounts),
+                labels: Object.keys(sentimentCounts),
+                type: 'pie',
+                marker: { colors: ["#8884d8", "#82ca9d", "#ffc658"] },
+              },
+            ]}
+            layout={{ title: 'Sentiment Pie Chart' }}
+          />
+        );
+      case "line":
+      default:
+        return (
+          <Plot
+            data={[
+              {
+                x: comments.map((comment, index) => `Comment ${index + 1}`),
+                y: comments.map(comment => comment.sentiment.compound),
+                type: 'scatter',
+                mode: 'lines+markers',
+                marker: { color: '#8884d8' },
+              },
+            ]}
+            layout={{ title: 'Sentiment Line Chart' }}
+          />
+        );
+    }
+  };
 
   return (
     <div>
@@ -16,6 +72,11 @@ function CommentsDisplay({ comments }) {
           </li>
         ))}
       </ul>
+      <div className="chart-container">
+        <ResponsiveContainer width="100%" height={300}>
+          {renderChart()}
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 }

--- a/frontend/src/youtube_app/VideoDisplay.js
+++ b/frontend/src/youtube_app/VideoDisplay.js
@@ -1,16 +1,72 @@
 import React from 'react';
+import { LineChart, Line, BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import Plot from 'react-plotly.js';
 
-function VideoDisplay({ videoData }) {
+function VideoDisplay({ videoData, chartType }) {
   if (!videoData) {
     return <div>No video data to display.</div>;
   }
+
+  const renderChart = () => {
+    switch (chartType) {
+      case "bar":
+        return (
+          <Plot
+            data={[
+              {
+                x: videoData.comments.map((comment, index) => `Comment ${index + 1}`),
+                y: videoData.comments.map(comment => comment.sentiment.compound),
+                type: 'bar',
+                marker: { color: '#8884d8' },
+              },
+            ]}
+            layout={{ title: 'Sentiment Bar Chart' }}
+          />
+        );
+      case "pie":
+        const sentimentCounts = videoData.comments.reduce((acc, comment) => {
+          const sentiment = comment.sentiment.compound >= 0.05 ? 'Positive' : comment.sentiment.compound <= -0.05 ? 'Negative' : 'Neutral';
+          acc[sentiment] = (acc[sentiment] || 0) + 1;
+          return acc;
+        }, {});
+        return (
+          <Plot
+            data={[
+              {
+                values: Object.values(sentimentCounts),
+                labels: Object.keys(sentimentCounts),
+                type: 'pie',
+                marker: { colors: ["#8884d8", "#82ca9d", "#ffc658"] },
+              },
+            ]}
+            layout={{ title: 'Sentiment Pie Chart' }}
+          />
+        );
+      case "line":
+      default:
+        return (
+          <Plot
+            data={[
+              {
+                x: videoData.comments.map((comment, index) => `Comment ${index + 1}`),
+                y: videoData.comments.map(comment => comment.sentiment.compound),
+                type: 'scatter',
+                mode: 'lines+markers',
+                marker: { color: '#8884d8' },
+              },
+            ]}
+            layout={{ title: 'Sentiment Line Chart' }}
+          />
+        );
+    }
+  };
 
   return (
     <div>
       <h2>{videoData.snippet.title}</h2>
       <p>{videoData.snippet.description}</p>
       <p>Views: {videoData.statistics.viewCount}</p>
-      {/* Add more video details as needed */}
+      {renderChart()}
     </div>
   );
 }

--- a/templates/visualization.html
+++ b/templates/visualization.html
@@ -16,15 +16,31 @@
     <h1>Data Visualization</h1>
     <div id="visualization-container">
         <p>This page will display the data visualization.</p>
+        <label for="chart-type">Select Chart Type:</label>
+        <select id="chart-type">
+            <option value="line_chart.html">Line Chart</option>
+            <option value="bar_chart.html">Bar Chart</option>
+            <option value="pie_chart.html">Pie Chart</option>
+        </select>
         <iframe id="visualization-iframe" width="800" height="600" frameborder="0"></iframe>
     </div>
     <script>
         const visualizationIframe = document.getElementById('visualization-iframe');
+        const chartTypeSelect = document.getElementById('chart-type');
         const urlParams = new URLSearchParams(window.location.search);
         const visualizationFile = urlParams.get('visualization_file');
 
+        function updateIframeSource() {
+            const selectedChartType = chartTypeSelect.value;
+            visualizationIframe.src = selectedChartType;
+        }
+
+        chartTypeSelect.addEventListener('change', updateIframeSource);
+
         if (visualizationFile) {
             visualizationIframe.src = visualizationFile;
+        } else {
+            updateIframeSource();
         }
     </script>
 </body>


### PR DESCRIPTION
Add support for multiple chart types in data visualization components.

* **data_visualization.py**: Add `create_basic_charts` function to generate line, bar, and pie charts using Matplotlib and Plotly. Save charts as HTML files.
* **frontend/src/webui/components/visualization/SentimentChart.tsx**: Add `chartType` prop to specify chart type. Update component to render different chart types (line, bar, pie) using Plotly.
* **templates/visualization.html**: Add dropdown menu to select chart type. Update iframe source based on selected chart type. Add JavaScript to handle chart type selection.
* **backend/app.py**: Add route `/api/visualizations/<video_id>/<chart_type>` to generate and return specified chart type. Update existing visualization routes to support different chart types.
* **frontend/src/youtube_app/CommentsDisplay.js**: Add `chartType` prop to specify chart type. Update component to render different chart types (line, bar, pie) using Plotly.
* **frontend/src/youtube_app/VideoDisplay.js**: Add `chartType` prop to specify chart type. Update component to render different chart types (line, bar, pie) using Plotly.

